### PR TITLE
use rapidfuzz instead of fuzzywuzzy

### DIFF
--- a/gb/api.py
+++ b/gb/api.py
@@ -6,7 +6,7 @@ from datetime import datetime
 
 import requests
 import humanize
-from fuzzywuzzy import process
+from rapidfuzz import process
 
 from gb import helpers
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,7 +16,6 @@ enum34==1.1.6
 Flask==0.12
 Flask-Ask==0.8.0
 futures==3.0.5
-fuzzywuzzy==0.15.0
 hjson==2.0.2
 humanize==0.5.1
 idna==2.5
@@ -34,9 +33,9 @@ pycparser==2.17
 pyOpenSSL==16.2.0
 pyparsing==2.2.0
 python-dateutil==2.6.0
-python-Levenshtein==0.12.0
 python-slugify==1.2.1
 PyYAML==3.12
+rapidfuzz==0.7.6
 requests==2.13.0
 rsa==3.4.2
 s3transfer==0.1.10


### PR DESCRIPTION
FuzzyWuzzy is GPLv2 licensed which would force you to licence the whole project under GPLv2.
For this reason this Pullrequest replaces FuzzyWuzzy with  [rapidfuzz](https://github.com/maxbachmann/rapidfuzz) which is implementing the same algorithm but is based on a version of fuzzywuzzy that was MIT Licensed.
Rapidfuzz is:
- Mit licensed so it can be used with the license used by this project
- Is faster than FuzzyWuzzy